### PR TITLE
fix: 비밀번호 재설정 input/버튼 폭 로그인과 동일하게 수정

### DIFF
--- a/src/app/Find/ChangePassword/page.tsx
+++ b/src/app/Find/ChangePassword/page.tsx
@@ -147,7 +147,7 @@ const ChangePassword = () => {
               새롭게 설정할 비밀번호를 입력해주세요.
             </p>
           </div>
-          <form onSubmit={handleSubmit(onSubmit)}>
+          <form onSubmit={handleSubmit(onSubmit)} className={styles.loginForm}>
             <div className={styles.changePwdForm}>
               <div className={styles.inputGroup}>
                 <div className={styles.changePwdLabel}>새로운 비밀번호</div>


### PR DESCRIPTION
## 문제
비밀번호 재설정 페이지의 input과 "비밀번호 변경" 버튼이 로그인/회원가입보다 좁게 렌더링됨.

## 원인
`<form>`에 `width: 100%`가 없어 flex 컨테이너(`align-items: center`) 안에서 shrink-to-fit으로 줄어듦. 그 결과 내부 `width:100%` input·버튼이 글자 폭 수준으로 좁아짐.

- 로그인: `<form className={styles.loginForm}>` (`width:100%`) ✅
- 회원가입: `<form className={styles.joinForm}>` (`width:100%`) ✅
- 비밀번호 재설정: className 없음 ❌

## 수정
폼에 `className={styles.loginForm}` 추가 → 컨테이너 전체 폭을 채워 input·버튼이 로그인/회원가입과 동일한 폭이 됨.